### PR TITLE
Added MenuItemReview Menu to NavBar

### DIFF
--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -18,7 +18,7 @@ test:	# Run unit tests.
 
 .PHONY: test-mut
 test-mut:	# Run mutation tests.
-	npx stryker run
+	nm 
 
 .PHONY: mut
 mut: test-mut	# Alias for `test-mut`.

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -18,7 +18,7 @@ test:	# Run unit tests.
 
 .PHONY: test-mut
 test-mut:	# Run mutation tests.
-	nm 
+	npx stryker run
 
 .PHONY: mut
 mut: test-mut	# Alias for `test-mut`.

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -75,6 +75,18 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                   </NavDropdown>
                 )
               }
+              {
+                hasRole(currentUser, "ROLE_USER") && (
+                  <NavDropdown title="MenuItemReview" id="appnavbar-menuitemreviews-dropdown" data-testid="appnavbar-menuitemreviews-dropdown" >
+                    <NavDropdown.Item as={Link} to="/MenuItemReview/list" data-testid="appnavbar-menuitemreviews-list">List MenuItemReviews</NavDropdown.Item>
+                    {
+                      hasRole(currentUser, "ROLE_ADMIN") && (
+                        <NavDropdown.Item as={Link} to="/MenuItemReview/create" data-testid="appnavbar-menuitemreviews-create">Create MenuItemReviews</NavDropdown.Item>
+                      )
+                    }
+                  </NavDropdown>
+                )
+              }
             </Nav>
 
             <Nav className="ml-auto">

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -236,6 +236,55 @@ describe("AppNavbar tests", () => {
         await waitFor( () => expect(getByTestId(/appnavbar-dining-commons-list/)).toBeInTheDocument() );
 
     });
+
+    // menuitemreview navbar tests
+    test("renders the menuitemreviews menu correctly for a user", async () => {
+
+        const currentUser = currentUserFixtures.userOnly;
+        const systemInfo = systemInfoFixtures.showingBoth;
+
+        const doLogin = jest.fn();
+
+        const {getByTestId  } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => expect(getByTestId("appnavbar-menuitemreviews-dropdown")).toBeInTheDocument());
+        const dropdown = getByTestId("appnavbar-menuitemreviews-dropdown");
+        const aElement = dropdown.querySelector("a");
+        expect(aElement).toBeInTheDocument();
+        aElement?.click();
+        await waitFor( () => expect(getByTestId("appnavbar-menuitemreviews-list")).toBeInTheDocument() );
+
+    });
+
+    test("renders the menuitemreviews menu correctly for an admin", async () => {
+
+        const currentUser = currentUserFixtures.adminUser;
+        const systemInfo = systemInfoFixtures.showingBoth;
+
+        const doLogin = jest.fn();
+
+        const {getByTestId  } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => expect(getByTestId("appnavbar-menuitemreviews-dropdown")).toBeInTheDocument());
+        const dropdown = getByTestId("appnavbar-menuitemreviews-dropdown");
+        const aElement = dropdown.querySelector("a");
+        expect(aElement).toBeInTheDocument();
+        aElement?.click();
+        await waitFor( () => expect(getByTestId(/appnavbar-menuitemreviews-create/)).toBeInTheDocument() );
+
+    });
    
 });
 


### PR DESCRIPTION
Add MenuItemReview pull-down menu with “List MenuItemReviews” and "Create MenuItemReviews".
Menu Options go to their specific route URLs
Added Test cases for the MenuItemReview NavBar

Closes #21 