### PR TITLE
Added navbar link for UCSB dining menu items

### DIFF
--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -59,7 +59,11 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                 hasRole(currentUser, "ROLE_USER") && (
                   <NavDropdown title="Dining Commons Menu Item" id="appnavbar-ucsbiningcommonsmenuitem-dropdown" data-testid="appnavbar-diningcommonsmenuitem-dropdown" >
                     <NavDropdown.Item as={Link} to="/UCSBDiningCommonsMenuItem/list" data-testid="appnavbar-diningcommonsmenuitem-list">List Dining Commons MenuItems</NavDropdown.Item>
-                    <NavDropdown.Item as={Link} to="/UCSBDiningCommonsMenuItem/create" data-testid="appnavbar-diningcommonsmenuitem-create">Create Dining Commons MenuItems</NavDropdown.Item>
+                    {
+                      hasRole(currentUser, "ROLE_ADMIN") && (
+                      <NavDropdown.Item as={Link} to="/UCSBDiningCommonsMenuItem/create" data-testid="appnavbar-diningcommonsmenuitem-create">Create Dining Commons MenuItems</NavDropdown.Item>
+                      )
+                    }
                   </NavDropdown>
                 ) 
               }

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -58,10 +58,10 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
               { // Dining Commons menu item
                 hasRole(currentUser, "ROLE_USER") && (
                   <NavDropdown title="Dining Commons Menu Item" id="appnavbar-ucsbiningcommonsmenuitem-dropdown" data-testid="appnavbar-diningcommonsmenuitem-dropdown" >
-                    <NavDropdown.Item as={Link} to="/UCSBDiningCommonsMenuItem/list" data-testid="appnavbar-diningcommonsmenuitem-list">List</NavDropdown.Item>
-                    <NavDropdown.Item as={Link} to="/UCSBDiningCommonsMenuItem/create" data-testid="appnavbar-diningcommonsmenuitem-create">Create</NavDropdown.Item>
+                    <NavDropdown.Item as={Link} to="/UCSBDiningCommonsMenuItem/list" data-testid="appnavbar-diningcommonsmenuitem-list">List Dining Commons MenuItems</NavDropdown.Item>
+                    <NavDropdown.Item as={Link} to="/UCSBDiningCommonsMenuItem/create" data-testid="appnavbar-diningcommonsmenuitem-create">Create Dining Commons MenuItems</NavDropdown.Item>
                   </NavDropdown>
-                )
+                ) 
               }
                {
                 hasRole(currentUser, "ROLE_USER") && (

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -55,6 +55,14 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                   </NavDropdown>
                 )
               }
+              { // Dining Commons menu item
+                hasRole(currentUser, "ROLE_USER") && (
+                  <NavDropdown title="Dining Commons Menu Item" id="appnavbar-ucsbiningcommonsmenuitem-dropdown" data-testid="appnavbar-diningcommonsmenuitem-dropdown" >
+                    <NavDropdown.Item as={Link} to="/UCSBDiningCommonsMenuItem/list" data-testid="appnavbar-diningcommonsmenuitem-list">List</NavDropdown.Item>
+                    <NavDropdown.Item as={Link} to="/UCSBDiningCommonsMenuItem/create" data-testid="appnavbar-diningcommonsmenuitem-create">Create</NavDropdown.Item>
+                  </NavDropdown>
+                )
+              }
                {
                 hasRole(currentUser, "ROLE_USER") && (
                   <NavDropdown title="Dining Commons" id="appnavbar-dining-commons-dropdown" data-testid="appnavbar-dining-commons-dropdown" >

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -236,6 +236,54 @@ describe("AppNavbar tests", () => {
         await waitFor( () => expect(getByTestId(/appnavbar-dining-commons-list/)).toBeInTheDocument() );
 
     });
+
+    test("renders the ucsbdiningcommonmenuitem menu correctly for a user", async () => {
+
+        const currentUser = currentUserFixtures.userOnly;
+        const systemInfo = systemInfoFixtures.showingBoth;
+
+        const doLogin = jest.fn();
+
+        const {getByTestId  } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => expect(getByTestId("appnavbar-diningcommonsmenuitem-dropdown")).toBeInTheDocument());
+        const dropdown = getByTestId("appnavbar-diningcommonsmenuitem-dropdown");
+        const aElement = dropdown.querySelector("a");
+        expect(aElement).toBeInTheDocument();
+        aElement?.click();
+        await waitFor( () => expect(getByTestId("appnavbar-diningcommonsmenuitem-list")).toBeInTheDocument() );
+
+    });
+
+    test("renders the ucsbdiningcommonmenuitem menu correctly for an admin", async () => {
+
+        const currentUser = currentUserFixtures.adminUser;
+        const systemInfo = systemInfoFixtures.showingBoth;
+
+        const doLogin = jest.fn();
+
+        const {getByTestId  } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => expect(getByTestId("appnavbar-diningcommonsmenuitem-dropdown")).toBeInTheDocument());
+        const dropdown = getByTestId("appnavbar-diningcommonsmenuitem-dropdown");
+        const aElement = dropdown.querySelector("a");
+        expect(aElement).toBeInTheDocument();
+        aElement?.click();
+        await waitFor( () => expect(getByTestId(/appnavbar-diningcommonsmenuitem-create/)).toBeInTheDocument() );
+
+    });
    
 });
 

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -348,7 +348,7 @@ describe('AppNavbar tests', () => {
     await waitFor(() =>
       expect(getByTestId(/appnavbar-dining-commons-list/)).toBeInTheDocument()
     )
-    
+    })
       test("renders the ucsbdiningcommonmenuitem menu correctly for a user", async () => {
 
         const currentUser = currentUserFixtures.userOnly;


### PR DESCRIPTION
Added `Dinning Common Menu Item` to Navbar with options to list dining common menu items and create dining common menu items. When user clicks on list dining common menu items, the website will redirect to `UCSBDiningCommonsMenuItem/list`. When user clocks on create dining common menu items, the website will redirect to `/UCSBDiningCommonsMenuItem/create`. Can test by running the back-end and front-end to see.

Closes #8 