### PR TITLE
patch: increase stryker allowed time to avoid timeout

### DIFF
--- a/.github/workflows/34-frontend-mutation-testing.yml
+++ b/.github/workflows/34-frontend-mutation-testing.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 60
 
     strategy:
       matrix:


### PR DESCRIPTION
Increase the npx stryker run time from 40 to 60 minutes because mutation testing is timing out since it takes longer than 40 minutes to run.